### PR TITLE
fix: support FlutterFragmentActivity

### DIFF
--- a/android/src/main/kotlin/com/moderntechsolutions/phone_number_hint/PhoneNumberHintPlugin.kt
+++ b/android/src/main/kotlin/com/moderntechsolutions/phone_number_hint/PhoneNumberHintPlugin.kt
@@ -65,7 +65,7 @@ class PhoneNumberHintPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, A
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
-        activity = binding.activity as FlutterActivity
+        activity = binding.activity
         binding.addActivityResultListener(this)
     }
 
@@ -74,7 +74,7 @@ class PhoneNumberHintPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, A
     }
 
     override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
-        activity = binding.activity as FlutterActivity
+        activity = binding.activity
         binding.addActivityResultListener(this)
     }
 


### PR DESCRIPTION
There's an unnecessary cast being done to `FlutterActivity` which prevents this package from working w/ `FlutterFragmentActivity`. Just removing the cast fixes the issue.